### PR TITLE
Wrap the code with `if __name__ == "__main__":` when using SubprocVecEnv

### DIFF
--- a/experiments/a2c_2way-single-intersection.py
+++ b/experiments/a2c_2way-single-intersection.py
@@ -21,27 +21,28 @@ from stable_baselines import A2C
 
 write_route_file('nets/2way-single-intersection/single-intersection-gen.rou.xml', 400000, 100000)
 
-# multiprocess environment
-n_cpu = 2
-env = SubprocVecEnv([lambda: SumoEnvironment(net_file='nets/2way-single-intersection/single-intersection.net.xml',
-                                    route_file='nets/2way-single-intersection/single-intersection-gen.rou.xml',
-                                    out_csv_name='outputs/2way-single-intersection/a2c-contexts-5s-vmvm-400k',
-                                    single_agent=True,
-                                    use_gui=True,
-                                    num_seconds=400000,
-                                    min_green=5,
-                                    time_to_load_vehicles=120,
-                                    max_depart_delay=0,
-                                    phases=[
-                                        traci.trafficlight.Phase(32, "GGrrrrGGrrrr"),  
-                                        traci.trafficlight.Phase(2, "yyrrrryyrrrr"),
-                                        traci.trafficlight.Phase(32, "rrGrrrrrGrrr"),   
-                                        traci.trafficlight.Phase(2, "rryrrrrryrrr"),
-                                        traci.trafficlight.Phase(32, "rrrGGrrrrGGr"),   
-                                        traci.trafficlight.Phase(2, "rrryyrrrryyr"),
-                                        traci.trafficlight.Phase(32, "rrrrrGrrrrrG"), 
-                                        traci.trafficlight.Phase(2, "rrrrryrrrrry")
-                                        ]) for i in range(n_cpu)])
+if __name__ == "__main__":
+    # multiprocess environment
+    n_cpu = 2
+    env = SubprocVecEnv([lambda: SumoEnvironment(net_file='nets/2way-single-intersection/single-intersection.net.xml',
+                                        route_file='nets/2way-single-intersection/single-intersection-gen.rou.xml',
+                                        out_csv_name='outputs/2way-single-intersection/a2c-contexts-5s-vmvm-400k',
+                                        single_agent=True,
+                                        use_gui=True,
+                                        num_seconds=400000,
+                                        min_green=5,
+                                        time_to_load_vehicles=120,
+                                        max_depart_delay=0,
+                                        phases=[
+                                            traci.trafficlight.Phase(32, "GGrrrrGGrrrr"),  
+                                            traci.trafficlight.Phase(2, "yyrrrryyrrrr"),
+                                            traci.trafficlight.Phase(32, "rrGrrrrrGrrr"),   
+                                            traci.trafficlight.Phase(2, "rryrrrrryrrr"),
+                                            traci.trafficlight.Phase(32, "rrrGGrrrrGGr"),   
+                                            traci.trafficlight.Phase(2, "rrryyrrrryyr"),
+                                            traci.trafficlight.Phase(32, "rrrrrGrrrrrG"), 
+                                            traci.trafficlight.Phase(2, "rrrrryrrrrry")
+                                            ]) for i in range(n_cpu)])
 
-model = A2C(MlpPolicy, env, verbose=1, learning_rate=0.0001, lr_schedule='constant')
-model.learn(total_timesteps=1000000)
+    model = A2C(MlpPolicy, env, verbose=1, learning_rate=0.0001, lr_schedule='constant')
+    model.learn(total_timesteps=1000000)


### PR DESCRIPTION
According to `stable-baselines`'s documentation: https://stable-baselines.readthedocs.io/en/master/guide/vec_envs.html

> When using `SubprocVecEnv`, users must wrap the code in an `if __name__ == "__main__":` if using the `forkserver` or `spawn` start method (default on Windows). On Linux, the default start method is `fork` which is not thread safe and can create deadlocks.