### PR TITLE
Properly close the virtual display

### DIFF
--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -289,6 +289,10 @@ class SumoEnvironment(gym.Env):
         if not LIBSUMO:
             traci.switch(self.label)
         traci.close()
+        try:
+            self.disp.stop()
+        except AttributeError:
+            pass
         self.sumo = None
     
     def __del__(self):


### PR DESCRIPTION
This is something I noticed a few days ago in my other env with a similar pattern, so it might be good to fix it here as well.

Basically in some cases (I'm not sure right now - it might be always, or it might be if there's an exception somewhere in the training), the environment can get closed and python might finish, but the virtual display process will still run. This should take care of that issue.