### PR TITLE
Add shell script for automated running of tests; fixed file path error in tests.

### DIFF
--- a/tests/execute_tests.sh
+++ b/tests/execute_tests.sh
@@ -1,0 +1,9 @@
+# Colour Coding
+NC='\033[0m' 
+RED='\033[1;31m' 
+
+for f in *.py
+do
+    printf "${RED} Executing test: $f ${NC} \n"
+    python3 "$f"
+ done

--- a/tests/gym_test.py
+++ b/tests/gym_test.py
@@ -5,8 +5,8 @@ from gym.utils.env_checker import check_env
 def test_api():
     env = SumoEnvironment(single_agent=True,
                           num_seconds=100000,
-                          net_file='nets/single-intersection/single-intersection.net.xml',
-                          route_file='nets/single-intersection/single-intersection.rou.xml')
+                          net_file='../nets/single-intersection/single-intersection.net.xml',
+                          route_file='../nets/single-intersection/single-intersection.rou.xml')
     env.reset()
     check_env(env)
     env.close()

--- a/tests/pz_test.py
+++ b/tests/pz_test.py
@@ -3,9 +3,9 @@ import sumo_rl
 
 
 def test_api():
-    env = sumo_rl.env(net_file='nets/4x4-Lucas/4x4.net.xml',
-                   route_file='nets/4x4-Lucas/4x4c1c2c1c2.rou.xml',
-                   out_csv_name='outputs/4x4grid/test',
+    env = sumo_rl.env(net_file='../nets/4x4-Lucas/4x4.net.xml',
+                   route_file='../nets/4x4-Lucas/4x4c1c2c1c2.rou.xml',
+                   out_csv_name='../outputs/4x4grid/test',
                    use_gui=False,
                    num_seconds=80000)
     api_test(env)


### PR DESCRIPTION
This PR adds the following functionalities:
- Running tests is as simple as `./execute_tests.sh`. This will be useful when more tests are added, or when a github action for running tests is added to the repository, in which case the same command can be run when the action is called.
- Due to the file structure of the project, the script (or individual execution of the `.py` test files won't work. This PR fixes that by making the (small) correction of changing the relative file path of the input and output SUMO files.

Here is how the execution will look in the terminal: 
![Running Tests](https://media.discordapp.net/attachments/845744017056858172/936919671003832320/Screenshot_from_2022-01-29_15-13-36.png?width=1357&height=619 "Tests run locally")