### PR TITLE
Failing tests and added dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-REQUIRED = ['gym', 'numpy', 'pandas', 'pillow', 'pettingzoo']
+REQUIRED = ['gym==0.24.0', 'numpy', 'pandas', 'pillow', 'pettingzoo']
 
 extras = {
     "rendering": ["pyvirtualdisplay"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-REQUIRED = ['gym==0.24.0', 'numpy', 'pandas', 'pillow', 'pettingzoo']
+REQUIRED = ['gym==0.24.0', 'numpy', 'pandas', 'pillow', 'pettingzoo', 'sumolib', 'traci']
 
 extras = {
     "rendering": ["pyvirtualdisplay"]

--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -364,8 +364,8 @@ class SumoEnvironmentPZ(AECEnv, EzPickle):
     def seed(self, seed=None):
         self.randomizer, seed = seeding.np_random(seed)
 
-    def reset(self, seed=None):
-        self.env.reset(seed=seed)
+    def reset(self, seed: Optional[int] = None, return_info: bool = False, options: Optional[dict] = None):
+        self.env.reset(seed=seed, return_info=return_info, options=options)
         self.agents = self.possible_agents[:]
         self.agent_selection = self._agent_selector.reset()
         self.rewards = {agent: 0 for agent in self.agents}


### PR DESCRIPTION
1. In gym version 0.24.1, the gym_test was failing. I suggest fixing the version to 0.24.0 in the setup.
2. Fixed the signature of the reset method for the pettingzoo environment. It mismatched with the AECEnv, which caused the pz_test to fail.
3. Added missing dependencies "sumolib" and "traci" to setup.py.
4. Removed unused "find_packages" import in setup.py