### PR TITLE
Support for different reward function for different traffic lights

### DIFF
--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -49,7 +49,7 @@ class SumoEnvironment(gym.Env):
     :param min_green: (int) Minimum green time in a phase
     :param max_green: (int) Max green time in a phase
     :single_agent: (bool) If true, it behaves like a regular gym.Env. Else, it behaves like a MultiagentEnv (https://github.com/ray-project/ray/blob/master/python/ray/rllib/env/multi_agent_env.py)
-    :reward_fn: (str/function/dict) String with the name of the reward function used by the agents, a reward function, or dictionary with rewards functions assigned to individual traffic lights by its keys
+    :reward_fn: (str/function/dict) String with the name of the reward function used by the agents, a reward function, or dictionary with reward functions assigned to individual traffic lights by their keys
     :add_system_info: (bool) If true, it computes system metrics (total queue, total waiting time, average speed) in the info dictionary
     :add_per_agent_info: (bool) If true, it computes per-agent (per-traffic signal) metrics (average accumulated waiting time, average queue) in the info dictionary
     :sumo_seed: (int/string) Random seed for sumo. If 'random' it uses a randomly chosen seed.
@@ -135,7 +135,7 @@ class SumoEnvironment(gym.Env):
         self.ts_ids = list(conn.trafficlight.getIDList())
 
         if isinstance(self.reward_fn, dict):
-            self.traffic_signals = {}
+            self.traffic_signals = dict()
             for key, reward_fn_value in self.reward_fn.items():
                 self.traffic_signals[key] = TrafficSignal(
                     self,
@@ -223,7 +223,7 @@ class SumoEnvironment(gym.Env):
         self._start_simulation()
 
         if isinstance(self.reward_fn, dict):
-            self.traffic_signals = {}
+            self.traffic_signals = dict()
             for key, reward_fn_value in self.reward_fn.items():
                 self.traffic_signals[key] = TrafficSignal(
                     self,

--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -49,7 +49,7 @@ class SumoEnvironment(gym.Env):
     :param min_green: (int) Minimum green time in a phase
     :param max_green: (int) Max green time in a phase
     :single_agent: (bool) If true, it behaves like a regular gym.Env. Else, it behaves like a MultiagentEnv (https://github.com/ray-project/ray/blob/master/python/ray/rllib/env/multi_agent_env.py)
-    :reward_fn: (str/function) String with the name of the reward function used by the agents, or a reward function.
+    :reward_fn: (str/function/list/dict) String with the name of the reward function used by the agents, a reward function, list of reward functions, or dictionary with rewards functions assigned to individual traffic lights by its keys
     :add_system_info: (bool) If true, it computes system metrics (total queue, total waiting time, average speed) in the info dictionary
     :add_per_agent_info: (bool) If true, it computes per-agent (per-traffic signal) metrics (average accumulated waiting time, average queue) in the info dictionary
     :sumo_seed: (int/string) Random seed for sumo. If 'random' it uses a randomly chosen seed.
@@ -133,15 +133,60 @@ class SumoEnvironment(gym.Env):
             traci.start([sumolib.checkBinary('sumo'), '-n', self._net], label='init_connection'+self.label)
             conn = traci.getConnection('init_connection'+self.label)
         self.ts_ids = list(conn.trafficlight.getIDList())
-        self.traffic_signals = {ts: TrafficSignal(self, 
-                                                  ts, 
-                                                  self.delta_time, 
-                                                  self.yellow_time, 
-                                                  self.min_green, 
-                                                  self.max_green, 
-                                                  self.begin_time,
-                                                  self.reward_fn,
-                                                  conn) for ts in self.ts_ids}
+
+        # Dictionary reward functions handling
+        if isinstance(self.reward_fn, dict):
+            # Check if given dictionary contains only keys which are in ts_ids
+            if not all(ts_id in self.ts_ids for ts_id in self.reward_fn.keys()):
+                # TODO: Rewrite the error (?to exception)
+                print("Reward functions must be specified for every traffic signal id!")
+                return
+
+            self.traffic_signals = {}
+
+            for key, reward_fn_value in self.reward_fn.items():
+                self.traffic_signals[key] = TrafficSignal(
+                    self, 
+                    key, 
+                    self.delta_time, 
+                    self.yellow_time, 
+                    self.min_green, 
+                    self.max_green, 
+                    self.begin_time,
+                    reward_fn_value,
+                    conn
+                )
+        # List of reward functions handling
+        elif isinstance(self.reward_fn, list):
+            self.traffic_signals = {}
+
+            for idx, ts_id in enumerate(self.ts_ids):
+                self.traffic_signals[ts_id] = TrafficSignal(
+                    self, 
+                    ts_id, 
+                    self.delta_time, 
+                    self.yellow_time, 
+                    self.min_green, 
+                    self.max_green, 
+                    self.begin_time,
+                    self.reward_fn[idx%len(self.reward_fn)],
+                    conn
+                )
+
+        # Same reward function (str or callable) for every ts
+        else:
+            self.traffic_signals = {
+                ts: TrafficSignal(self, 
+                                ts, 
+                                self.delta_time, 
+                                self.yellow_time, 
+                                self.min_green, 
+                                self.max_green, 
+                                self.begin_time,
+                                self.reward_fn,
+                                conn) for ts in self.ts_ids
+            }
+        
         conn.close()
 
         self.vehicles = dict()
@@ -202,16 +247,58 @@ class SumoEnvironment(gym.Env):
         if seed is not None:
             self.sumo_seed = seed
         self._start_simulation()
+        
+        # Dictionary reward functions handling
+        if isinstance(self.reward_fn, dict):
 
-        self.traffic_signals = {ts: TrafficSignal(self, 
-                                                  ts, 
-                                                  self.delta_time, 
-                                                  self.yellow_time, 
-                                                  self.min_green, 
-                                                  self.max_green, 
-                                                  self.begin_time,
-                                                  self.reward_fn,
-                                                  self.sumo) for ts in self.ts_ids}
+            if not all(ts_id in self.ts_ids for ts_id in self.reward_fn.keys()):
+                # TODO: Rewrite the error
+                print("Reward functions must be specified for every traffic signal id!")
+                return
+
+            self.traffic_signals = {}
+            print("\n[REWARD_FN TYPE: DICT]")
+
+            for key, reward_fn_value in self.reward_fn.items():
+                self.traffic_signals[key] = TrafficSignal(
+                    self, 
+                    key, 
+                    self.delta_time, 
+                    self.yellow_time, 
+                    self.min_green, 
+                    self.max_green, 
+                    self.begin_time,
+                    reward_fn_value,
+                    self.sumo
+                )
+
+        # List of reward functions handling
+        elif isinstance(self.reward_fn, list):
+            self.traffic_signals = {}
+
+            for idx, ts_id in enumerate(self.ts_ids):
+                self.traffic_signals[ts_id] = TrafficSignal(
+                    self, 
+                    ts_id, 
+                    self.delta_time, 
+                    self.yellow_time, 
+                    self.min_green, 
+                    self.max_green, 
+                    self.begin_time,
+                    self.reward_fn[idx%len(self.reward_fn)],
+                    self.sumo
+                )
+        else:
+            self.traffic_signals = {ts: TrafficSignal(self, 
+                                                    ts, 
+                                                    self.delta_time, 
+                                                    self.yellow_time, 
+                                                    self.min_green, 
+                                                    self.max_green, 
+                                                    self.begin_time,
+                                                    self.reward_fn,
+                                                    self.sumo) for ts in self.ts_ids}
+
         self.vehicles = dict()
 
         if self.single_agent:


### PR DESCRIPTION
I added a support for setting different reward function for each traffic light in env constructor. Reward functions can now be passed as an dict with keys specifying the traffic signal ID.