### PR TITLE
Support for custom observation function, minor changes to my previous implementation

### DIFF
--- a/sumo_rl/__init__.py
+++ b/sumo_rl/__init__.py
@@ -1,3 +1,3 @@
-from sumo_rl.environment.env import SumoEnvironment
+from sumo_rl.environment.env import SumoEnvironment, TrafficSignal
 from sumo_rl.environment.env import env, parallel_env
 from sumo_rl.environment.resco_envs import grid4x4, arterial4x4, ingolstadt1, ingolstadt7, ingolstadt21, cologne1, cologne3, cologne8

--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -50,7 +50,7 @@ class SumoEnvironment(gym.Env):
     :param max_green: (int) Max green time in a phase
     :single_agent: (bool) If true, it behaves like a regular gym.Env. Else, it behaves like a MultiagentEnv (https://github.com/ray-project/ray/blob/master/python/ray/rllib/env/multi_agent_env.py)
     :reward_fn: (str/function/dict) String with the name of the reward function used by the agents, a reward function, or dictionary with reward functions assigned to individual traffic lights by their keys
-    :observation_fn: (str/function) String with the name of the observation function or a observation function
+    :observation_fn: (str/function) String with the name of the observation function or a callable observation function itself
     :add_system_info: (bool) If true, it computes system metrics (total queue, total waiting time, average speed) in the info dictionary
     :add_per_agent_info: (bool) If true, it computes per-agent (per-traffic signal) metrics (average accumulated waiting time, average queue) in the info dictionary
     :sumo_seed: (int/string) Random seed for sumo. If 'random' it uses a randomly chosen seed.

--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -135,6 +135,7 @@ class SumoEnvironment(gym.Env):
             traci.start([sumolib.checkBinary('sumo'), '-n', self._net], label='init_connection'+self.label)
             conn = traci.getConnection('init_connection'+self.label)
         self.ts_ids = list(conn.trafficlight.getIDList())
+        self.observation_fn = observation_fn
 
         if isinstance(self.reward_fn, dict):
             self.traffic_signals = {ts: TrafficSignal(self,
@@ -159,7 +160,6 @@ class SumoEnvironment(gym.Env):
 
         conn.close()
 
-        self.observation_fn = observation_fn
         self.vehicles = dict()
         self.reward_range = (-float('inf'), float('inf'))
         self.metadata = {}


### PR DESCRIPTION
Hello Lucas,
This PR contains following changes:
1) Edit of my previous Implementation ([PR-119](https://github.com/LucasAlegre/sumo-rl/pull/119)), just to match the code style.
2) Support for custom observation function, which can be passed in SumoEnvironment constructor as a Callable or a string. I also added the observation_fns dictionary to the class, as we plan to implement few more observation functions soon. The observation functions can also be registered to this dictionary with the class method.
3) Similar changes were made also for reward functions (like dictionary with reward functions with registration class method), but most important one was to move the checking of the reward function type to the constructor, because it was checked everytime compute_reward method was called. 