### PR TITLE
Support for custom observations (both observation function and observation space)

### DIFF
--- a/sumo_rl/__init__.py
+++ b/sumo_rl/__init__.py
@@ -1,3 +1,3 @@
-from sumo_rl.environment.env import SumoEnvironment, TrafficSignal
+from sumo_rl.environment.env import SumoEnvironment, TrafficSignal, ObservationFunction
 from sumo_rl.environment.env import env, parallel_env
 from sumo_rl.environment.resco_envs import grid4x4, arterial4x4, ingolstadt1, ingolstadt7, ingolstadt21, cologne1, cologne3, cologne8

--- a/sumo_rl/__init__.py
+++ b/sumo_rl/__init__.py
@@ -1,3 +1,3 @@
-from sumo_rl.environment.env import SumoEnvironment
+from sumo_rl.environment.env import SumoEnvironment, TrafficSignal
 from sumo_rl.environment.env import env, parallel_env
 from sumo_rl.environment.resco_envs import grid4x4, arterial4x4, ingolstadt1, ingolstadt7, ingolstadt21, cologne1, cologne3, cologne8

--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -19,6 +19,7 @@ from pettingzoo.utils.agent_selector import agent_selector
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 from .traffic_signal import TrafficSignal
+from .observations import *
 
 LIBSUMO = 'LIBSUMO_AS_TRACI' in os.environ
 
@@ -50,7 +51,7 @@ class SumoEnvironment(gym.Env):
     :param max_green: (int) Max green time in a phase
     :single_agent: (bool) If true, it behaves like a regular gym.Env. Else, it behaves like a MultiagentEnv (https://github.com/ray-project/ray/blob/master/python/ray/rllib/env/multi_agent_env.py)
     :reward_fn: (str/function/dict) String with the name of the reward function used by the agents, a reward function, or dictionary with reward functions assigned to individual traffic lights by their keys
-    :observation_fn: (str/function) String with the name of the observation function or a callable observation function itself
+    :observation_class: (ObservationFunction) Inherited class which has both the observation function and observation space
     :add_system_info: (bool) If true, it computes system metrics (total queue, total waiting time, average speed) in the info dictionary
     :add_per_agent_info: (bool) If true, it computes per-agent (per-traffic signal) metrics (average accumulated waiting time, average queue) in the info dictionary
     :sumo_seed: (int/string) Random seed for sumo. If 'random' it uses a randomly chosen seed.
@@ -83,7 +84,7 @@ class SumoEnvironment(gym.Env):
         max_green: int = 50, 
         single_agent: bool = False,
         reward_fn: Union[str,Callable,dict] = 'diff-waiting-time',
-        observation_fn: Union[str,Callable] = 'default',
+        observation_class: ObservationFunction = DefaultObservationFunction,
         add_system_info: bool = True,
         add_per_agent_info: bool = True,
         sumo_seed: Union[str,int] = 'random', 
@@ -135,7 +136,7 @@ class SumoEnvironment(gym.Env):
             traci.start([sumolib.checkBinary('sumo'), '-n', self._net], label='init_connection'+self.label)
             conn = traci.getConnection('init_connection'+self.label)
         self.ts_ids = list(conn.trafficlight.getIDList())
-        self.observation_fn = observation_fn
+        self.observation_class = observation_class
 
         if isinstance(self.reward_fn, dict):
             self.traffic_signals = {ts: TrafficSignal(self,

--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -19,7 +19,7 @@ from pettingzoo.utils.agent_selector import agent_selector
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 from .traffic_signal import TrafficSignal
-from .observations import *
+from .observations import ObservationFunction, DefaultObservationFunction
 
 LIBSUMO = 'LIBSUMO_AS_TRACI' in os.environ
 

--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -50,7 +50,7 @@ class SumoEnvironment(gym.Env):
     :param max_green: (int) Max green time in a phase
     :single_agent: (bool) If true, it behaves like a regular gym.Env. Else, it behaves like a MultiagentEnv (https://github.com/ray-project/ray/blob/master/python/ray/rllib/env/multi_agent_env.py)
     :reward_fn: (str/function/dict) String with the name of the reward function used by the agents, a reward function, or dictionary with reward functions assigned to individual traffic lights by their keys
-    :observation_fn: (str/function) String with the name of the observation function or a observation function
+    :observation_fn: (str/function) String with the name of the observation function or a callable observation function itself
     :add_system_info: (bool) If true, it computes system metrics (total queue, total waiting time, average speed) in the info dictionary
     :add_per_agent_info: (bool) If true, it computes per-agent (per-traffic signal) metrics (average accumulated waiting time, average queue) in the info dictionary
     :sumo_seed: (int/string) Random seed for sumo. If 'random' it uses a randomly chosen seed.

--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -135,6 +135,7 @@ class SumoEnvironment(gym.Env):
             traci.start([sumolib.checkBinary('sumo'), '-n', self._net], label='init_connection'+self.label)
             conn = traci.getConnection('init_connection'+self.label)
         self.ts_ids = list(conn.trafficlight.getIDList())
+        self.observation_fn = observation_fn
 
         if isinstance(self.reward_fn, dict):
             self.traffic_signals = {ts: TrafficSignal(self,
@@ -159,7 +160,6 @@ class SumoEnvironment(gym.Env):
 
         conn.close()
 
-        self.observation_fn = observation_fn
         self.vehicles = dict()
         self.reward_range = (-float('inf'), float('inf'))
         self.metadata = {}

--- a/sumo_rl/environment/observations.py
+++ b/sumo_rl/environment/observations.py
@@ -1,0 +1,47 @@
+from .traffic_signal import TrafficSignal
+from abc import abstractmethod
+from typing import Callable
+from gymnasium import spaces
+import numpy as np
+
+class ObservationFunction:
+    """
+    Abstract base class for observation functions.
+    """
+    def __init__(self, ts: TrafficSignal):
+        self.ts = ts
+
+    @abstractmethod
+    def __call__(self):
+        """
+        Subclasses must override this method.
+        """
+        pass
+
+    @abstractmethod
+    def observation_space(self):
+        """
+        Subclasses must override this method.
+        """
+        pass
+
+
+class DefaultObservationFunction(ObservationFunction):
+    def __init__(self, ts: TrafficSignal):
+        # super().__init__(ts)
+        self.ts = ts
+
+    def __call__(self):
+        phase_id = [1 if self.ts.green_phase == i else 0 for i in range(self.ts.num_green_phases)]  # one-hot encoding
+        min_green = [0 if self.ts.time_since_last_phase_change < self.ts.min_green + self.ts.yellow_time else 1]
+        density = self.ts.get_lanes_density()
+        queue = self.ts.get_lanes_queue()
+        observation = np.array(phase_id + min_green + density + queue, dtype=np.float32)
+        return observation
+
+    def observation_space(self):
+        return spaces.Box(
+            low=np.zeros(self.ts.num_green_phases+1+2*len(self.ts.lanes), dtype=np.float32), 
+            high=np.ones(self.ts.num_green_phases+1+2*len(self.ts.lanes), dtype=np.float32)
+        )
+

--- a/sumo_rl/environment/observations.py
+++ b/sumo_rl/environment/observations.py
@@ -1,6 +1,5 @@
 from .traffic_signal import TrafficSignal
 from abc import abstractmethod
-from typing import Callable
 from gymnasium import spaces
 import numpy as np
 
@@ -28,8 +27,7 @@ class ObservationFunction:
 
 class DefaultObservationFunction(ObservationFunction):
     def __init__(self, ts: TrafficSignal):
-        # super().__init__(ts)
-        self.ts = ts
+        super().__init__(ts)
 
     def __call__(self):
         phase_id = [1 if self.ts.green_phase == i else 0 for i in range(self.ts.num_green_phases)]  # one-hot encoding


### PR DESCRIPTION
Hello Lucas,
as we discussed in [PR-126](https://github.com/LucasAlegre/sumo-rl/pull/126), I separated the observations to another file and solved the previous issue - where the user might specify only observation function without specifying observation space. 

User can now specify the observations by creating class which will be inherited from base `ObservationFunction` class and adding it as a `observation_class` parameter when creating `SumoEnvironment` object. If the observation class is not defined, `DefaultObservationFunction` is used instead, so this change shouldn't affect previous implementations.

One thing I am not completely sure of is the `discrete_observation_space` attribute of the `TrafficSignal` class. I didn't find any usage of this attribute so I am not sure if it should be also considered in observations. Or maybe I can just delete that attribute in another commit? 😄 Please, let me know.