### PR TITLE
fix: set traci default view if it doesn't exist

### DIFF
--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -236,6 +236,8 @@ class SumoEnvironment(gym.Env):
             self.sumo = traci.getConnection(self.label)
 
         if self.use_gui or self.render_mode is not None:
+            if "DEFAULT_VIEW" not in dir(traci.gui):
+                traci.gui.DEFAULT_VIEW = 'View #0'
             self.sumo.gui.setSchema(traci.gui.DEFAULT_VIEW, "real world")
 
     def reset(self, seed: Optional[int] = None, **kwargs):


### PR DESCRIPTION
This change allows you to use LIB_SUMO_AS_TRACI=1 with use_gui=True in some situations.