### PR TITLE
Fixed runtime issues of RLLib

### DIFF
--- a/experiments/ppo_4x4grid.py
+++ b/experiments/ppo_4x4grid.py
@@ -20,6 +20,7 @@ import sumo_rl
 
 
 if __name__ == "__main__":
+    print(os.getcwd())
     ray.init()
 
     env_name = "4x4grid"


### PR DESCRIPTION
The RLLib codes did not run because the latest versions of Ray had some of the attributes and methods `DEPRECATED` and `sumo-rl` did not mention any specific version of `ray[rllib]` that could be used.

Hence, I removed those deprecated attributes and methods from the experiment notebooks.