### PR TITLE
pettingzoo 1.25+ compatibility

### DIFF
--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -18,7 +18,13 @@ import sumolib
 import traci
 from gymnasium.utils import EzPickle, seeding
 from pettingzoo import AECEnv
-from pettingzoo.utils import agent_selector, wrappers
+from pettingzoo.utils import wrappers
+try:
+    # pettingzoo 1.25+
+    from pettingzoo.utils import AgentSelector
+except ImportError:
+    # pettingzoo 1.24 or earlier
+    from pettingzoo.utils import agent_selector as AgentSelector
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 from .observations import DefaultObservationFunction, ObservationFunction
@@ -521,7 +527,7 @@ class SumoEnvironmentPZ(AECEnv, EzPickle):
 
         self.agents = self.env.ts_ids
         self.possible_agents = self.env.ts_ids
-        self._agent_selector = agent_selector(self.agents)
+        self._agent_selector = AgentSelector(self.agents)
         self.agent_selection = self._agent_selector.reset()
         # spaces
         self.action_spaces = {a: self.env.action_spaces(a) for a in self.agents}


### PR DESCRIPTION
pettingzoo.utils.agent_selector no longer points to the deprecated class agent_selector but to the module agent_selector.py - newer code should use AgentSelector