### PR TITLE
Update CI to use latest ubuntu version

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   linux-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']


### PR DESCRIPTION
Fixes: canceling of test runs as Ubuntu 20.04 was deprecated and has been removed.