### PR TITLE
Sanitize sumo_seed to 32-bit integer to prevent crash

### DIFF
--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -152,6 +152,8 @@ class SumoEnvironment(gym.Env):
         self.reward_fn = reward_fn
         self.reward_weights = reward_weights
         self.sumo_seed = sumo_seed
+        if isinstance(self.sumo_seed, int):
+            self.sumo_seed &= 0x7FFFFFFF
         self.fixed_ts = fixed_ts
         self.sumo_warnings = sumo_warnings
         self.additional_sumo_cmd = additional_sumo_cmd
@@ -265,7 +267,7 @@ class SumoEnvironment(gym.Env):
         self.metrics = []
 
         if seed is not None:
-            self.sumo_seed = seed
+            self.sumo_seed = seed & 0x7FFFFFFF
         self._start_simulation()
 
         self._build_traffic_signals(self.sumo)

--- a/sumo_rl/environment/env.py
+++ b/sumo_rl/environment/env.py
@@ -153,7 +153,7 @@ class SumoEnvironment(gym.Env):
         self.reward_weights = reward_weights
         self.sumo_seed = sumo_seed
         if isinstance(self.sumo_seed, int):
-            self.sumo_seed &= 0x7FFFFFFF
+            self.sumo_seed &= 0x7FFFFFFF  # Ensure 32 bit non-negative seed
         self.fixed_ts = fixed_ts
         self.sumo_warnings = sumo_warnings
         self.additional_sumo_cmd = additional_sumo_cmd
@@ -267,7 +267,7 @@ class SumoEnvironment(gym.Env):
         self.metrics = []
 
         if seed is not None:
-            self.sumo_seed = seed & 0x7FFFFFFF
+            self.sumo_seed = seed & 0x7FFFFFFF  # Ensure 32 bit non-negative seed
         self._start_simulation()
 
         self._build_traffic_signals(self.sumo)


### PR DESCRIPTION
I am using SUMO-RL with RL Baselines3 Zoo, and the randomly generated seeds are often 64-bit integers. This causes SUMO to crash because it expects a 32-bit signed integer. 
This change sanitizes `sumo_seed` with a bitmask to avoid this crash without compromising reproducibility.